### PR TITLE
issue #15 update error message

### DIFF
--- a/drivers-license-input.html
+++ b/drivers-license-input.html
@@ -174,7 +174,7 @@ An Input field that validates the driver license based on the rules in the /rule
       _stateChanged: function(state) {
         this.$.driversLicenseNumber.disabled = false;
         this._pattern = this._rules[state].rule;
-        this.errorMessage = `Drivers License should have at least ${this._rules[state].description.join(' ')}`;
+        this.errorMessage = `Drivers License should have at least ${this._rules[state].description.join(' or ')}`;
       },
 
       _rulesChanged: function(rules) {


### PR DESCRIPTION
The error message previously had space as a separator, which is a bit confusing. replace `'  '` with `' or '` to make more sense.